### PR TITLE
Change minor typo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
             ssh-keyscan -p ${SSHPORT} ${HOST_NAME} >> ~/.ssh/known_hosts
 
       - run:
-          name: Deploy (Not Master)
+          name: Deploy
           command: |
             if [ "${CIRCLE_BRANCH}" != "master" ]; then
               ssh -p ${SSHPORT} ${USER_NAME}@${HOST_NAME} "rm -rf /var/www/test/*"


### PR DESCRIPTION
```
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
             ssh-keyscan -p ${SSHPORT} ${HOST_NAME} >> ~/.ssh/known_hosts

       - run:
-          name: Deploy (Not Master)
+          name: Deploy
           command: |
             if [ "${CIRCLE_BRANCH}" != "master" ]; then
               ssh -p ${SSHPORT} ${USER_NAME}@${HOST_NAME} "rm -rf /var/www/test/*"
```